### PR TITLE
Check if user exists on system

### DIFF
--- a/putty2openssh
+++ b/putty2openssh
@@ -4,40 +4,50 @@
 RFC4716key=$1
 USERNAME=${2:-$USER}
 
+# Check if keyfile exists
 if [[ ! -f "$RFC4716key" ]];
   then
     echo "ERROR: Keyfile does not exist: $RFC4716key"
     exit 4
   else
+    #Check if keyfile is RFC 4716 format
     ssh-keygen -if "$RFC4716key" &> /dev/null
     if [[ $? != 0 ]];
       then
         echo "ERROR: $RFC4716key is NOT a RFC 4716 keyfile."
+        exit 8
       else
-        # Generates public key using ssh-keygen
-        publickey=$(ssh-keygen -if "$RFC4716key")
+        id "$USERNAME" &> /dev/null
+        if [[ $? != 0 ]];
+          then
+            echo "ERROR: Username not present on system: $USERNAME"
+            exit 16
+          else
+            # Generates public key using ssh-keygen
+            publickey=$(ssh-keygen -if "$RFC4716key")
 
-        # Extracts comment from input publickey
-        #   1. awk extracts muiltiline comment header
-        #   2. sed removes trailing backslashes from comment header
-        #   3. tr converts multiline comment into single line comment
-        #   4. sed removes 'Comment: ' keyword and quotes
-        comment=$(cat "$RFC4716key" | awk '/Comment:/,/[^\\]$/' | sed 's_\\$__' | tr -d '\n' | sed -e 's_Comment: __' -e 's_"__g')
+            # Extracts comment from input publickey
+            #   1. awk extracts muiltiline comment header
+            #   2. sed removes trailing backslashes from comment header
+            #   3. tr converts multiline comment into single line comment
+            #   4. sed removes 'Comment: ' keyword and quotes
+            comment=$(cat "$RFC4716key" | awk '/Comment:/,/[^\\]$/' | sed 's_\\$__' | tr -d '\n' | sed -e 's_Comment: __' -e 's_"__g')
 
-        # Concatenates the publickey and comment
-        openssh="$publickey $comment"
+            # Concatenates the publickey and comment
+            openssh="$publickey $comment"
 
-        # Creates user's .ssh directory if not present
-        mkdir -p "/home/$USERNAME/.ssh/"
+            # Creates user's .ssh directory if not present
+            mkdir -p "/home/$USERNAME/.ssh/"
 
-        # Appends extracted key w. comment to users authorized_keys file
-        #  to the end of the file, leaving existing keys untouched
-        echo $openssh >> "/home/$USERNAME/.ssh/authorized_keys"
+            # Appends extracted key w. comment to users authorized_keys file
+            #  to the end of the file, leaving existing keys untouched
+            echo $openssh >> "/home/$USERNAME/.ssh/authorized_keys"
 
-        # Fix folder ownership, or else sshd will not accept authorized_keys file
-        chown --quiet --recursive "$USERNAME" "/home/$USERNAME"
+            # Fix folder ownership, or else sshd will not accept authorized_keys file
+            chown --quiet --recursive "$USERNAME" "/home/$USERNAME"
 
-        echo "Added public key $RFC4716key to $USERNAME's authorized_keys file"
-        echo "$RFC4716key comment: $comment"
+            echo "Added public key $RFC4716key to $USERNAME's authorized_keys file"
+            echo "$RFC4716key comment: $comment"
+        fi
     fi
 fi


### PR DESCRIPTION
Previously we would not check if user was present on system. Ownership
of the 'user' `~/.ssh/authorized_keys` would not be set properly.

This fixes #3 