### PR TITLE
Check if public key is already present

### DIFF
--- a/putty2openssh
+++ b/putty2openssh
@@ -26,28 +26,36 @@ if [[ ! -f "$RFC4716key" ]];
             # Generates public key using ssh-keygen
             publickey=$(ssh-keygen -if "$RFC4716key")
 
-            # Extracts comment from input publickey
-            #   1. awk extracts muiltiline comment header
-            #   2. sed removes trailing backslashes from comment header
-            #   3. tr converts multiline comment into single line comment
-            #   4. sed removes 'Comment: ' keyword and quotes
-            comment=$(cat "$RFC4716key" | awk '/Comment:/,/[^\\]$/' | sed 's_\\$__' | tr -d '\n' | sed -e 's_Comment: __' -e 's_"__g')
+            #Check if publickey is already present in users ~/.ssh/authorized_keys file
+            grep "$publickey" "/home/$USERNAME/.ssh/authorized_keys" &> /dev/null
+            if [[ $? == 0 ]];
+              then
+                echo "WARNING: Key is already present in $USERNAME's authorized_keys file"
+                exit 32
+              else
+                # Extracts comment from input publickey
+                #   1. awk extracts muiltiline comment header
+                #   2. sed removes trailing backslashes from comment header
+                #   3. tr converts multiline comment into single line comment
+                #   4. sed removes 'Comment: ' keyword and quotes
+                comment=$(cat "$RFC4716key" | awk '/Comment:/,/[^\\]$/' | sed 's_\\$__' | tr -d '\n' | sed -e 's_Comment: __' -e 's_"__g')
 
-            # Concatenates the publickey and comment
-            openssh="$publickey $comment"
+                # Concatenates the publickey and comment
+                openssh="$publickey $comment"
 
-            # Creates user's .ssh directory if not present
-            mkdir -p "/home/$USERNAME/.ssh/"
+                # Creates user's .ssh directory if not present
+                mkdir -p "/home/$USERNAME/.ssh/"
 
-            # Appends extracted key w. comment to users authorized_keys file
-            #  to the end of the file, leaving existing keys untouched
-            echo $openssh >> "/home/$USERNAME/.ssh/authorized_keys"
+                # Appends extracted key w. comment to users authorized_keys file
+                #  to the end of the file, leaving existing keys untouched
+                echo $openssh >> "/home/$USERNAME/.ssh/authorized_keys"
 
-            # Fix folder ownership, or else sshd will not accept authorized_keys file
-            chown --quiet --recursive "$USERNAME" "/home/$USERNAME"
+                # Fix folder ownership, or else sshd will not accept authorized_keys file
+                chown --quiet --recursive "$USERNAME" "/home/$USERNAME"
 
-            echo "Added public key $RFC4716key to $USERNAME's authorized_keys file"
-            echo "$RFC4716key comment: $comment"
+                echo "Added public key $RFC4716key to $USERNAME's authorized_keys file"
+                echo "$RFC4716key comment: $comment"
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
If the public key is already present in the users `~/.ssh/authorized_keys` file, we skip adding it another time.

Fixes #2