### PR TITLE
Feature Warn for missing comment

### DIFF
--- a/putty2openssh
+++ b/putty2openssh
@@ -58,32 +58,33 @@ if [[ ! -f "$RFC4716key" ]];
                         *   )  echo "Invalid option, try again"
                       esac
                     done
+                  else
+                    #Check if key comment is repeated
+                    repeatedComment_lines=$(grep "$comment" "/home/$USERNAME/.ssh/authorized_keys")
+                    if [[ ! -z $repeatedComment_lines ]];
+                      then
+                        echo "WARNING: Key(s) with similar comment is already present"
+                        repeatedComment_count=1
+                        echo "  New key comment: $comment"
+                        # List the comments of the keys with similar comments
+                        echo "$repeatedComment_lines" | while read commentLine; do
+                          repeatedComment_comment=$(echo $commentLine | sed 's_^.*==__' | sed 's_^\ __' )
+                          echo "  Similar Key Comment $repeatedComment_count : $repeatedComment_comment"
+                          ((repeatedComment_count++))
+                        done
+                        echo "Add current key to authorized_keys ?"
+                        select yn in "Yes" "No" ; do
+                          case $yn in
+                            Yes )  keyAdd=true;
+                                   break;;
+                            No  )  keyAdd=false;
+                                   break;;
+                            *   )  echo "Invalid option, try again"
+                          esac
+                        done
+                    fi
                 fi
 
-                #Check if key comment is repeated
-                repeatedComment_lines=$(grep "$comment" "/home/$USERNAME/.ssh/authorized_keys")
-                if [[ ! -z $repeatedComment_lines ]];
-                  then
-                    echo "WARNING: Key(s) with similar comment is already present"
-                    repeatedComment_count=1
-                    echo "  New key comment: $comment"
-                    # List the comments of the keys with similar comments
-                    echo "$repeatedComment_lines" | while read commentLine; do
-                      repeatedComment_comment=$(echo $commentLine | sed 's_^.*==__' | sed 's_^\ __' )
-                      echo "  Similar Key Comment $repeatedComment_count : $repeatedComment_comment"
-                      ((repeatedComment_count++))
-                    done
-                    echo "Add current key to authorized_keys ?"
-                    select yn in "Yes" "No" ; do
-                      case $yn in
-                        Yes )  keyAdd=true;
-                               break;;
-                        No  )  keyAdd=false;
-                               break;;
-                        *   )  echo "Invalid option, try again"
-                      esac
-                    done
-                fi
                 if [[ $keyAdd = true ]];
                   then
                     comment="$comment ADDED on: $(date)"

--- a/putty2openssh
+++ b/putty2openssh
@@ -45,6 +45,21 @@ if [[ ! -f "$RFC4716key" ]];
                 #   4. sed removes 'Comment: ' keyword and quotes
                 comment=$(cat "$RFC4716key" | awk '/Comment:/,/[^\\]$/' | sed 's_\\$__' | tr -d '\n' | sed -e 's_Comment: __' -e 's_"__g')
 
+                if [[ -z $comment ]];
+                  then
+                    echo "WARNING: Key contains no comment."
+                    echo "  Add current key to authorized_keys ?"
+                    select yn in "Yes" "No" ; do
+                      case $yn in
+                        Yes )  keyAdd=true;
+                               break;;
+                        No  )  keyAdd=false;
+                               break;;
+                        *   )  echo "Invalid option, try again"
+                      esac
+                    done
+                fi
+
                 #Check if key comment is repeated
                 repeatedComment_lines=$(grep "$comment" "/home/$USERNAME/.ssh/authorized_keys")
                 if [[ ! -z $repeatedComment_lines ]];


### PR DESCRIPTION
Script will now warn when trying to add key with no comment.

Script will also now check for similar comments only if new key's comment is not empty

FIXES #9